### PR TITLE
Add client-server mode: acid serve and acid run

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,37 @@
+package client
+
+import (
+	"database/sql"
+	"fmt"
+	"net"
+
+	"github.com/rusinikita/acid/protocol"
+	"github.com/rusinikita/acid/runner"
+	"github.com/rusinikita/acid/sequence"
+)
+
+// Run connects to the server at serverAddr, executes seq against db,
+// and streams events to the server for visualization.
+func Run(db *sql.DB, seq sequence.Sequence, serverAddr string) error {
+	conn, err := net.Dial("tcp", serverAddr)
+	if err != nil {
+		return fmt.Errorf("connect to server %s: %w", serverAddr, err)
+	}
+	defer conn.Close()
+
+	r := runner.New(db)
+	iter := runner.NewIterator(r)
+	iter.Run(seq)
+
+	for {
+		e, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if err := protocol.WriteEvent(conn, e); err != nil {
+			return fmt.Errorf("send event: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/event/event.go
+++ b/event/event.go
@@ -50,3 +50,7 @@ func (e Event) IsWaiting(trx call.TrxID) bool {
 func (e Event) TestSetup() bool {
 	return e.testSetup
 }
+
+func (e Event) Waiting() []call.TrxID {
+	return e.waiting
+}

--- a/main.go
+++ b/main.go
@@ -8,16 +8,33 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/rusinikita/acid/client"
 	"github.com/rusinikita/acid/config"
 	"github.com/rusinikita/acid/db"
 	"github.com/rusinikita/acid/runner"
 	"github.com/rusinikita/acid/sequence"
+	"github.com/rusinikita/acid/server"
 	"github.com/rusinikita/acid/ui/list"
 	"github.com/rusinikita/acid/ui/router"
 	"github.com/rusinikita/acid/ui/run"
 )
 
 func main() {
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "serve":
+			runServe()
+			return
+		case "run":
+			runClient()
+			return
+		}
+	}
+
+	runStandalone()
+}
+
+func runStandalone() {
 	var filePath string
 	flag.StringVar(&filePath, "file", "", "path to .toml sequence file")
 	flag.StringVar(&filePath, "f", "", "path to .toml sequence file")
@@ -60,5 +77,78 @@ func main() {
 	_, err := p.Run()
 	if err != nil {
 		log.Fatal(err)
+	}
+}
+
+func runServe() {
+	fs := flag.NewFlagSet("serve", flag.ExitOnError)
+	port := fs.String("port", "7331", "TCP port to listen on")
+	_ = fs.Parse(os.Args[2:])
+
+	addr := ":" + *port
+	srv := server.New(addr)
+	if err := srv.ListenAndServe(); err != nil {
+		log.Fatalf("server: %v", err)
+	}
+
+	log.Printf("acid server listening on %s", addr)
+
+	source := runner.NewChannelSource(srv.Channel())
+
+	routes := map[string]tea.Model{
+		"run": run.NewServerRunTable(source, *port),
+	}
+
+	app := router.NewRouter(routes, router.Route("run"))
+
+	p := tea.NewProgram(
+		app,
+		tea.WithAltScreen(),
+		tea.WithMouseCellMotion(),
+	)
+
+	_, err := p.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func runClient() {
+	fs := flag.NewFlagSet("run", flag.ExitOnError)
+	serverAddr := fs.String("server", "localhost:7331", "server address (host:port)")
+	filePath := fs.String("file", "", "path to .toml sequence file")
+	fs.StringVar(filePath, "f", "", "path to .toml sequence file")
+	_ = fs.Parse(os.Args[2:])
+
+	var seq sequence.Sequence
+
+	if *filePath != "" {
+		db.LoadEnv(filepath.Dir(*filePath))
+		var err error
+		seq, err = config.Load(*filePath)
+		if err != nil {
+			log.Fatalf("load %s: %v", *filePath, err)
+		}
+	} else {
+		args := fs.Args()
+		if len(args) == 0 {
+			log.Fatal("usage: acid run <sequence-name> [--server host:port]")
+		}
+		name := args[0]
+		var ok bool
+		for _, s := range sequence.Sequences {
+			if s.Name == name {
+				seq, ok = s, true
+				break
+			}
+		}
+		if !ok {
+			log.Fatalf("sequence %q not found", name)
+		}
+	}
+
+	conn := db.Connect()
+	if err := client.Run(conn, seq, *serverAddr); err != nil {
+		log.Fatalf("client: %v", err)
 	}
 }

--- a/protocol/messages.go
+++ b/protocol/messages.go
@@ -1,0 +1,129 @@
+package protocol
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/rusinikita/acid/call"
+	"github.com/rusinikita/acid/event"
+)
+
+// EventMessage is the JSON wire format for a single event.
+type EventMessage struct {
+	Kind      string         `json:"kind"` // "call" | "result"
+	Trx       string         `json:"trx"`
+	TestSetup bool           `json:"test_setup"`
+	Waiting   []string       `json:"waiting,omitempty"`
+	Step      *StepMessage   `json:"step,omitempty"`
+	Result    *ResultMessage `json:"result,omitempty"`
+}
+
+type StepMessage struct {
+	Code       string `json:"code"`
+	TrxCommand int    `json:"trx_command"`
+}
+
+type ResultMessage struct {
+	RowsAffected int64          `json:"rows_affected"`
+	Error        string         `json:"error,omitempty"`
+	Rows         *SelectMessage `json:"rows,omitempty"`
+}
+
+type SelectMessage struct {
+	Columns []string   `json:"columns"`
+	Rows    [][]string `json:"rows"`
+}
+
+func Marshal(e event.Event) EventMessage {
+	msg := EventMessage{
+		Trx:       string(e.Trx()),
+		TestSetup: e.TestSetup(),
+	}
+	for _, w := range e.Waiting() {
+		msg.Waiting = append(msg.Waiting, string(w))
+	}
+
+	if step := e.Step(); step != nil {
+		msg.Kind = "call"
+		msg.Step = &StepMessage{
+			Code:       step.Code,
+			TrxCommand: int(step.TrxCommand),
+		}
+	} else {
+		msg.Kind = "result"
+		r := e.Result()
+		rm := &ResultMessage{RowsAffected: r.RowsAffected}
+		if r.Error != nil {
+			rm.Error = r.Error.Error()
+		}
+		if r.Rows != nil {
+			rm.Rows = &SelectMessage{
+				Columns: r.Rows.Columns,
+				Rows:    r.Rows.Rows,
+			}
+		}
+		msg.Result = rm
+	}
+	return msg
+}
+
+func Unmarshal(msg EventMessage) event.Event {
+	waiting := make([]call.TrxID, len(msg.Waiting))
+	for i, w := range msg.Waiting {
+		waiting[i] = call.TrxID(w)
+	}
+
+	trx := call.TrxID(msg.Trx)
+
+	if msg.Kind == "call" && msg.Step != nil {
+		step := call.Step{
+			Code:       msg.Step.Code,
+			Trx:        trx,
+			TrxCommand: call.TrxCommandType(msg.Step.TrxCommand),
+			TestSetup:  msg.TestSetup,
+		}
+		return event.Call(step, waiting)
+	}
+
+	step := call.Step{Trx: trx, TestSetup: msg.TestSetup}
+	result := call.ExecResult{}
+	if msg.Result != nil {
+		result.RowsAffected = msg.Result.RowsAffected
+		if msg.Result.Error != "" {
+			result.Error = errors.New(msg.Result.Error)
+		}
+		if msg.Result.Rows != nil {
+			result.Rows = &call.SelectResult{
+				Columns: msg.Result.Rows.Columns,
+				Rows:    msg.Result.Rows.Rows,
+			}
+		}
+	}
+	return event.Result(step, result, waiting)
+}
+
+// WriteEvent serializes e as a JSON line and writes it to w.
+func WriteEvent(w io.Writer, e event.Event) error {
+	data, err := json.Marshal(Marshal(e))
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = w.Write(data)
+	return err
+}
+
+// ReadEvent reads one JSON line from r and deserializes it into an event.Event.
+func ReadEvent(r *bufio.Reader) (event.Event, error) {
+	line, err := r.ReadBytes('\n')
+	if err != nil {
+		return event.Event{}, err
+	}
+	var msg EventMessage
+	if err := json.Unmarshal(line, &msg); err != nil {
+		return event.Event{}, err
+	}
+	return Unmarshal(msg), nil
+}

--- a/runner/source.go
+++ b/runner/source.go
@@ -1,0 +1,25 @@
+package runner
+
+import (
+	"github.com/rusinikita/acid/event"
+	"github.com/rusinikita/acid/sequence"
+)
+
+// ChannelSource satisfies the ui/run runner interface for server mode.
+// Events are provided externally via a channel populated by the network listener.
+type ChannelSource struct {
+	ch <-chan event.Event
+}
+
+func NewChannelSource(ch <-chan event.Event) *ChannelSource {
+	return &ChannelSource{ch: ch}
+}
+
+// Run is a no-op; the server receives events from the network, not from a local DB.
+func (cs *ChannelSource) Run(_ sequence.Sequence) {}
+
+// Next blocks until an event is available or the channel is closed.
+func (cs *ChannelSource) Next() (event.Event, bool) {
+	e, ok := <-cs.ch
+	return e, ok
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"bufio"
+	"io"
+	"log"
+	"net"
+
+	"github.com/rusinikita/acid/event"
+	"github.com/rusinikita/acid/protocol"
+)
+
+// Server listens for a single TCP client connection and forwards events to a channel.
+type Server struct {
+	addr  string
+	bound string
+	ch    chan event.Event
+}
+
+func New(addr string) *Server {
+	return &Server{
+		addr: addr,
+		ch:   make(chan event.Event),
+	}
+}
+
+// Channel returns the read-only channel that the TUI drains for incoming events.
+func (s *Server) Channel() <-chan event.Event {
+	return s.ch
+}
+
+// Addr returns the actual bound address (e.g. "127.0.0.1:14322").
+// Only valid after ListenAndServe returns without error.
+func (s *Server) Addr() string {
+	return s.bound
+}
+
+// ListenAndServe binds to the address and accepts one client in a background goroutine.
+// It returns as soon as the listener is bound.
+func (s *Server) ListenAndServe() error {
+	ln, err := net.Listen("tcp", s.addr)
+	if err != nil {
+		return err
+	}
+	s.bound = ln.Addr().String()
+
+	go func() {
+		defer ln.Close()
+		defer close(s.ch)
+
+		conn, err := ln.Accept()
+		if err != nil {
+			log.Printf("server accept: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		s.readEvents(conn)
+	}()
+
+	return nil
+}
+
+func (s *Server) readEvents(r io.Reader) {
+	br := bufio.NewReader(r)
+	for {
+		e, err := protocol.ReadEvent(br)
+		if err != nil {
+			if err != io.EOF {
+				log.Printf("server read: %v", err)
+			}
+			return
+		}
+		s.ch <- e
+	}
+}

--- a/tests/client_server_test.go
+++ b/tests/client_server_test.go
@@ -1,0 +1,61 @@
+package tests
+
+import (
+	"os"
+
+	"github.com/rusinikita/acid/client"
+	"github.com/rusinikita/acid/config"
+	"github.com/rusinikita/acid/protocol"
+	"github.com/rusinikita/acid/runner"
+	"github.com/rusinikita/acid/server"
+)
+
+func (s *PostgresSuite) TestClientServerRoundTrip() {
+	// Load sequence from a temp TOML file (same content as toml_load_test)
+	f, err := os.CreateTemp("", "client_server_*.toml")
+	s.Require().NoError(err)
+	defer os.Remove(f.Name())
+	_, err = f.WriteString(lostUpdateTOML)
+	s.Require().NoError(err)
+	s.Require().NoError(f.Close())
+
+	seq, err := config.Load(f.Name())
+	s.Require().NoError(err)
+
+	// Start a server on a random port
+	srv := server.New("127.0.0.1:0")
+	s.Require().NoError(srv.ListenAndServe())
+
+	// Run client in background: connects to server, executes seq, streams events
+	clientErr := make(chan error, 1)
+	go func() {
+		clientErr <- client.Run(s.db, seq, srv.Addr())
+	}()
+
+	// Collect all events the server received and marshal them for comparison
+	var received []protocol.EventMessage
+	for e := range srv.Channel() {
+		msg := protocol.Marshal(e)
+		msg.Waiting = nil // waiting is timing-dependent; excluded from comparison
+		received = append(received, msg)
+	}
+	s.Require().NoError(<-clientErr)
+
+	// Build reference by running the same sequence locally
+	r := runner.New(s.db)
+	iter := runner.NewIterator(r)
+	iter.Run(seq)
+
+	var expected []protocol.EventMessage
+	for {
+		e, ok := iter.Next()
+		if !ok {
+			break
+		}
+		msg := protocol.Marshal(e)
+		msg.Waiting = nil
+		expected = append(expected, msg)
+	}
+
+	s.Equal(expected, received)
+}

--- a/tests/lost_update_sequence_test.go
+++ b/tests/lost_update_sequence_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rusinikita/acid/sequence"
 )
 
-func (s *LostUpdateSuite) TestLostUpdateSequence() {
+func (s *PostgresSuite) TestLostUpdateSequence() {
 	tx1 := call.TrxID("first")
 	tx2 := call.TrxID("second")
 

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -37,17 +37,17 @@ func configureDockerHost() {
 	}
 }
 
-type LostUpdateSuite struct {
+type PostgresSuite struct {
 	suite.Suite
 	pgContainer *tcpostgres.PostgresContainer
 	db          *sql.DB
 }
 
-func TestLostUpdateSuite(t *testing.T) {
-	suite.Run(t, new(LostUpdateSuite))
+func TestPostgresSuite(t *testing.T) {
+	suite.Run(t, new(PostgresSuite))
 }
 
-func (s *LostUpdateSuite) SetupSuite() {
+func (s *PostgresSuite) SetupSuite() {
 	ctx := context.Background()
 
 	pgContainer, err := tcpostgres.Run(ctx,
@@ -69,7 +69,7 @@ func (s *LostUpdateSuite) SetupSuite() {
 	s.db = db
 }
 
-func (s *LostUpdateSuite) TearDownSuite() {
+func (s *PostgresSuite) TearDownSuite() {
 	if s.db != nil {
 		s.db.Close()
 	}

--- a/ui/run/events_table.go
+++ b/ui/run/events_table.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
+	"github.com/rusinikita/acid/call"
 	"github.com/rusinikita/acid/event"
 	"github.com/rusinikita/acid/sequence"
 	"github.com/rusinikita/acid/ui/router"
@@ -17,8 +18,9 @@ import (
 type model struct {
 	runner runner
 
-	running bool
-	window  tea.WindowSizeMsg
+	running    bool
+	serverMode bool
+	window     tea.WindowSizeMsg
 
 	table *table.Table
 	vp    viewport.Model
@@ -63,7 +65,45 @@ func NewRunTable(runner runner, db string, sequences []sequence.Sequence) tea.Mo
 	return m
 }
 
+// NewServerRunTable creates a run model for server mode. Events are received
+// from the network via source; no local DB connection or sequence selection is needed.
+func NewServerRunTable(source runner, port string) tea.Model {
+	data := &eventData{
+		onlyStepsMode: true,
+		transactions:  []call.TrxID{""},
+	}
+
+	t := table.New().Data(data)
+
+	m := &model{
+		runner:     source,
+		running:    true,
+		serverMode: true,
+
+		table: t,
+		data:  data,
+
+		help: help.New(),
+		db:   ":" + port,
+	}
+
+	styleFunc := func(row, _ int) lipgloss.Style {
+		switch {
+		case row == table.HeaderRow:
+			return theme.HeaderStyle
+		default:
+			return theme.OddRowStyle.Width(m.window.Width/m.data.Columns() - m.data.Columns())
+		}
+	}
+	t.StyleFunc(styleFunc)
+
+	return m
+}
+
 func (m *model) Init() tea.Cmd {
+	if m.serverMode {
+		return readNextEvent(m.runner)
+	}
 	return nil
 }
 
@@ -110,6 +150,9 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		m.UpdateViewport()
 	case router.Message:
+		if m.serverMode {
+			return m, nil
+		}
 		m.data.clean()
 		m.currentSequence = msg.DataInt
 
@@ -153,6 +196,10 @@ func (m *model) bordersHeight() int {
 }
 
 func (m *model) View() string {
+	if m.serverMode && len(m.data.events) == 0 {
+		return "Waiting for connection on " + m.db + "...\n\nPress q to quit."
+	}
+
 	menu := "  " + m.help.ShortHelpView(theme.DefaultKB.Menu())
 	dbLabel := fmt.Sprint("seq ", m.currentSequence+1, " ", m.db)
 	dbLabelLen := len(dbLabel)


### PR DESCRIPTION
## Summary

- `acid serve [--port 7331]` — starts a TUI visualization window, listens for events over TCP (port defaults to 7331)
- `acid run <sequence> [--server localhost:7331]` — connects to DB, runs the sequence, streams events to the server (server defaults to localhost:7331)
- `acid` (no args) — existing standalone behavior unchanged

## New packages

- `protocol/` — JSON-newline wire format for events over TCP
- `server/` — TCP listener that feeds events to the TUI via a channel
- `client/` — connects to DB and server, runs the sequence, streams events
- `runner/source.go` — `ChannelSource` that satisfies the TUI runner interface from a network channel

## Changes

- `event/event.go` — added `Waiting()` accessor needed for serialization
- `ui/run/events_table.go` — added `NewServerRunTable`, server mode waiting state
- `main.go` — subcommand dispatch

## Test plan

- [ ] `acid serve` shows "Waiting for connection on :7331..."
- [ ] `acid serve --port 9000` listens on :9000
- [ ] `acid run "Lost Update"` connects to localhost:7331 and server shows events populating in real-time
- [ ] `acid run "Lost Update" --server localhost:9000` connects to :9000
- [ ] `acid` (no args) still works as before
- [ ] `acid run "Nonexistent"` prints error and exits