### PR TITLE
Add acid toggle command to control result visibility on server

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -39,7 +39,7 @@ func runServe() {
 	source := runner.NewChannelSource(srv.Channel())
 
 	routes := map[string]tea.Model{
-		"run": run.NewServerRunTable(source, port),
+		"run": run.NewServerRunTable(source, port, srv.ToggleCh()),
 	}
 
 	app := router.NewRouter(routes, router.Route("run"))

--- a/cmd/toggle.go
+++ b/cmd/toggle.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var togglePort string
+
+var toggleCmd = &cobra.Command{
+	Use:   "toggle",
+	Short: "Toggle result visibility on the running acid server",
+	Run: func(cmd *cobra.Command, args []string) {
+		toggleMode()
+	},
+}
+
+func init() {
+	toggleCmd.Flags().StringVarP(&togglePort, "port", "p", "7331", "port of the acid server")
+	rootCmd.AddCommand(toggleCmd)
+}
+
+func toggleMode() {
+	url := "http://localhost:" + togglePort + "/toggle-mode"
+	resp, err := http.Post(url, "", nil) //nolint:noctx
+	if err != nil {
+		fmt.Printf("acid server is NOT running on port %s\n", togglePort)
+		os.Exit(1)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		fmt.Printf("error: %s\n", body)
+		os.Exit(1)
+	}
+
+	fmt.Println(string(body))
+}

--- a/server/server.go
+++ b/server/server.go
@@ -2,28 +2,40 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/http"
+	"sync"
 
 	"github.com/rusinikita/acid/event"
 	"github.com/rusinikita/acid/protocol"
 )
 
 // Server is an HTTP server that receives events from a remote client.
-// GET  /health  — liveness probe
-// POST /event   — deliver one event (JSON body: protocol.EventMessage)
-// POST /done    — signal end of stream; closes the event channel
+// GET  /health        — liveness probe
+// POST /event         — deliver one event (JSON body: protocol.EventMessage)
+// POST /done          — signal end of stream; closes the event channel
+// POST /toggle-mode   — toggle result visibility on the server TUI
 type Server struct {
-	addr  string
-	bound string
-	ch    chan event.Event
+	addr     string
+	bound    string
+	ch       chan event.Event
+	toggleCh chan struct{}
+	mu       sync.Mutex
+	visible  bool // false = hidden (onlyStepsMode=true), true = visible
 }
 
 func New(addr string) *Server {
 	return &Server{
-		addr: addr,
-		ch:   make(chan event.Event),
+		addr:     addr,
+		ch:       make(chan event.Event),
+		toggleCh: make(chan struct{}, 1),
 	}
+}
+
+// ToggleCh returns the channel that fires when a /toggle-mode request is received.
+func (s *Server) ToggleCh() <-chan struct{} {
+	return s.toggleCh
 }
 
 // Channel returns the read-only channel that the TUI drains for incoming events.
@@ -65,6 +77,23 @@ func (s *Server) ListenAndServe() error {
 	mux.HandleFunc("POST /done", func(w http.ResponseWriter, r *http.Request) {
 		s.ch <- event.Done()
 		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("POST /toggle-mode", func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		select {
+		case s.toggleCh <- struct{}{}:
+			s.visible = !s.visible
+			v := s.visible
+			s.mu.Unlock()
+			from, to := "hidden", "visible"
+			if !v {
+				from, to = "visible", "hidden"
+			}
+			fmt.Fprintf(w, "toggled: %s -> %s", from, to)
+		default:
+			s.mu.Unlock()
+			http.Error(w, "toggle already pending", http.StatusConflict)
+		}
 	})
 
 	go func() { _ = http.Serve(ln, mux) }()

--- a/ui/run/events_table.go
+++ b/ui/run/events_table.go
@@ -16,7 +16,8 @@ import (
 )
 
 type model struct {
-	runner runner
+	runner   runner
+	toggleCh <-chan struct{}
 
 	running    bool
 	serverMode bool
@@ -67,7 +68,8 @@ func NewRunTable(runner runner, db string, sequences []sequence.Sequence) tea.Mo
 
 // NewServerRunTable creates a run model for server mode. Events are received
 // from the network via source; no local DB connection or sequence selection is needed.
-func NewServerRunTable(source runner, port string) tea.Model {
+// toggleCh fires when the /toggle-mode endpoint is called, switching result visibility.
+func NewServerRunTable(source runner, port string, toggleCh <-chan struct{}) tea.Model {
 	data := &eventData{
 		onlyStepsMode: true,
 		transactions:  []call.TrxID{""},
@@ -77,6 +79,7 @@ func NewServerRunTable(source runner, port string) tea.Model {
 
 	m := &model{
 		runner:     source,
+		toggleCh:   toggleCh,
 		running:    true,
 		serverMode: true,
 
@@ -102,7 +105,7 @@ func NewServerRunTable(source runner, port string) tea.Model {
 
 func (m *model) Init() tea.Cmd {
 	if m.serverMode {
-		return readNextEvent(m.runner)
+		return tea.Batch(readNextEvent(m.runner), waitForToggle(m.toggleCh))
 	}
 	return nil
 }
@@ -118,6 +121,15 @@ func readNextEvent(r runner) func() tea.Msg {
 	}
 }
 
+type toggleModeMsg struct{}
+
+func waitForToggle(ch <-chan struct{}) tea.Cmd {
+	return func() tea.Msg {
+		<-ch
+		return toggleModeMsg{}
+	}
+}
+
 func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 
@@ -129,7 +141,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, router.Route("list")
 		}
 
-		if key.Matches(msg, theme.DefaultKB.Mode) {
+		if !m.serverMode && key.Matches(msg, theme.DefaultKB.Mode) {
 			m.data.onlyStepsMode = !m.data.onlyStepsMode
 			m.vp.YOffset = 0
 			m.UpdateViewport()
@@ -163,6 +175,11 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		return m, tea.Sequence(run, readNextEvent(m.runner))
+	case toggleModeMsg:
+		m.data.onlyStepsMode = !m.data.onlyStepsMode
+		m.vp.YOffset = 0
+		m.UpdateViewport()
+		return m, waitForToggle(m.toggleCh)
 	case newEvent:
 		if msg.Event.IsStart() {
 			m.data.clean()
@@ -206,7 +223,11 @@ func (m *model) View() string {
 		return "Waiting for connection on " + m.db + "...\n\nPress q to quit."
 	}
 
-	menu := "  " + m.help.ShortHelpView(theme.DefaultKB.Menu())
+	menuBindings := theme.DefaultKB.Menu()
+	if m.serverMode {
+		menuBindings = theme.DefaultKB.ServerMenu()
+	}
+	menu := "  " + m.help.ShortHelpView(menuBindings)
 	dbLabel := fmt.Sprint("seq ", m.currentSequence+1, " ", m.db)
 	dbLabelLen := len(dbLabel)
 	dbLabel = theme.StatusLineStyle.Render(dbLabel)

--- a/ui/theme/keys.go
+++ b/ui/theme/keys.go
@@ -48,3 +48,12 @@ func (b KeyBindings) Menu() []key.Binding {
 		b.ShowSetup,
 	}
 }
+
+func (b KeyBindings) ServerMenu() []key.Binding {
+	return []key.Binding{
+		b.Up,
+		b.Down,
+		b.Back,
+		b.ShowSetup,
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `acid toggle` CLI command that hits `POST /toggle-mode` on the running server and prints the transition (e.g. `toggled: hidden -> visible`)
- Server tracks the current visibility state and returns the before/after in the response body
- `m`/`space` key is removed from the help bar and ignored in server mode — visibility is controlled exclusively via `acid toggle`

## Test plan
- [ ] Start server: `acid serve`
- [ ] Run `acid toggle` — should print `toggled: hidden -> visible`
- [ ] Run `acid toggle` again — should print `toggled: visible -> hidden`
- [ ] Confirm `m`/`space` has no effect and is absent from the help bar in server TUI
- [ ] `acid toggle --port <n>` works against a non-default port