### PR TITLE
Fix init: AGENTS.md + CLAUDE.md/GEMINI.md symlinks, drop broken --system-prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ go.work.sum
 # IDE
 .idea
 .claude/worktrees
+dist

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,8 +35,8 @@ release:
   github:
     owner: rusinikita
     name: acid
-  draft: true
-  prerelease: true
+  draft: false
+  prerelease: false
 
 homebrew_casks:
   - name: acid

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ init:
 		echo ".env file created."; \
 	fi
 
+ifneq (,$(wildcard ./.env))
+    include .env
+    export
+endif
+
 # Run database in docker container
 rundbs:
 	docker-compose up -d

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.10.9
+	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.41.0
 )
@@ -73,7 +74,6 @@ require (
 	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.2 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/testcontainers/testcontainers-go v0.41.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect

--- a/initcmd/init.go
+++ b/initcmd/init.go
@@ -31,9 +31,11 @@ func Run(args []string) {
 	var created []string
 
 	flat := map[string]string{
-		".env":      "templates/env.example",
-		"agents.md": "templates/agents.md",
-		"learning_plan.md": "templates/learning_plan.md",
+		".env":               "templates/env.example",
+		"agents.md":          "templates/agents.md",
+		"learning_plan.md":   "templates/learning_plan.md",
+		"docker-compose.yml": "templates/docker-compose.yml",
+		"Makefile":           "templates/Makefile",
 	}
 	for dest, src := range flat {
 		data, _ := templates.ReadFile(src)
@@ -87,15 +89,20 @@ func printSummary(dir string, created []string) {
 		fmt.Printf("  %d. cd %s\n", step, dir)
 		step++
 	}
-	fmt.Printf("  %d. Edit .env with your database connection details\n", step)
+	fmt.Printf("  %d. Start a database:  make pg   (PostgreSQL) or  make mysql\n", step)
+	step++
+	fmt.Printf("  %d. Edit .env if you're using a custom database connection\n", step)
 	step++
 	fmt.Printf("  %d. Open two terminal panes:\n", step)
-	fmt.Println("       FIRST    acid serve")
+	fmt.Println("       FIRST    make serve")
 	fmt.Println("       SECOND   claude --system-prompt agents.md")
 	step++
 	fmt.Printf("  %d. Say \"Let's start\" — the AI agent will guide you\n", step)
 	step++
 	fmt.Printf("  %d. Run scenarios manually at any time:\n", step)
 	fmt.Println("       acid run -f sequences/lost_update.toml")
+	step++
+	fmt.Printf("  %d. Keep acid up to date:\n", step)
+	fmt.Println("       make update")
 	fmt.Println()
 }

--- a/initcmd/init.go
+++ b/initcmd/init.go
@@ -32,7 +32,7 @@ func Run(args []string) {
 
 	flat := map[string]string{
 		".env":               "templates/env.example",
-		"agents.md":          "templates/agents.md",
+		"AGENTS.md":          "templates/agents.md",
 		"learning_plan.md":   "templates/learning_plan.md",
 		"docker-compose.yml": "templates/docker-compose.yml",
 		"Makefile":           "templates/Makefile",
@@ -42,6 +42,13 @@ func Run(args []string) {
 		full := filepath.Join(targetDir, dest)
 		if writeNew(full, data) {
 			created = append(created, dest)
+		}
+	}
+
+	for _, link := range []string{"CLAUDE.md", "GEMINI.md"} {
+		dest := filepath.Join(targetDir, link)
+		if symlinkNew(dest, "AGENTS.md") {
+			created = append(created, link+" -> AGENTS.md")
 		}
 	}
 
@@ -76,6 +83,20 @@ func writeNew(path string, content []byte) bool {
 	return true
 }
 
+// symlinkNew creates a symlink at link pointing to target only if link does not exist.
+// Returns true if the symlink was created.
+func symlinkNew(link, target string) bool {
+	if _, err := os.Lstat(link); err == nil {
+		fmt.Printf("  skip (exists)  %s\n", link)
+		return false
+	}
+	if err := os.Symlink(target, link); err != nil {
+		fmt.Fprintf(os.Stderr, "init: symlink %s: %v\n", link, err)
+		os.Exit(1)
+	}
+	return true
+}
+
 func printSummary(dir string, created []string) {
 	fmt.Printf("\nScaffolded learning environment in: %s\n\n", dir)
 	fmt.Println("Created:")
@@ -95,7 +116,7 @@ func printSummary(dir string, created []string) {
 	step++
 	fmt.Printf("  %d. Open two terminal panes:\n", step)
 	fmt.Println("       FIRST    make serve")
-	fmt.Println("       SECOND   claude --system-prompt agents.md")
+	fmt.Println("       SECOND   claude")
 	step++
 	fmt.Printf("  %d. Say \"Let's start\" — the AI agent will guide you\n", step)
 	step++

--- a/initcmd/templates/Makefile
+++ b/initcmd/templates/Makefile
@@ -1,0 +1,25 @@
+# Start PostgreSQL (matches .env default)
+pg:
+	docker-compose up -d postgres
+
+# Start MySQL (switch DB_DRIVER in .env)
+mysql:
+	docker-compose up -d mysql
+
+# Stop all database containers
+stop:
+	docker-compose down
+
+# Start acid server (default port 7331)
+serve:
+	acid serve
+
+# Update acid — detects Homebrew or falls back to install script
+update:
+	@if command -v brew >/dev/null 2>&1 && brew list --cask acid >/dev/null 2>&1; then \
+		brew upgrade --cask acid; \
+	else \
+		curl -fsSL https://raw.githubusercontent.com/rusinikita/acid/main/install.sh | sh; \
+	fi
+
+.PHONY: pg mysql stop serve update

--- a/initcmd/templates/agents.md
+++ b/initcmd/templates/agents.md
@@ -10,7 +10,7 @@ this file, a `learning_plan.md` curriculum, and a `sequences/` folder of runnabl
 
 # Personality
 
-- Warm, direct, Socratic — ask what the student already knows before explaining anything
+- Warm, direct, Socratic — never ask "what do you already know about X?" before a topic; go straight to the demo and prediction
 - One question per message, no exceptions
 - Celebrate correct predictions; treat wrong predictions as the real learning moment
 - Keep explanations under 4 sentences; let the tool output do the talking
@@ -94,14 +94,13 @@ Use for Phases 1–7 and the Capstone. acid is useful for:
 1. Explain the concept in 2–3 sentences
 2. Write the TOML file to sequences/<name>.toml
 3. Run: acid run -f sequences/<name>.toml
-4. Ask: "What do you think appeared on the server screen?"
+4. Ask: "What will the final result be, and why?"
    (Results are hidden — student must predict before seeing anything)
 5. Wait for the student's answer — do not proceed until they respond
 6. Run: acid toggle  (results become visible on the student's screen)
-7. Ask: "What do you see? Was your prediction right?"
-8. Debrief in 2–4 sentences: why did that happen?
-9. Append one entry to learning_history.md
-10. Ask one follow-up question or move to the next concept
+7. Debrief in 2–4 sentences: why did that happen? (do NOT ask "what do you see?" — just debrief)
+8. Append one entry to learning_history.md
+9. Ask one follow-up question or move to the next concept
 ```
 
 ## Mode B — Socratic Dialogue
@@ -113,12 +112,11 @@ tables — acid cannot demonstrate them.
 **Loop for every dialogue topic:**
 
 ```
-1. Ask what the student already knows about this topic
-2. Introduce the concept with one concrete real-world example
-3. Ask an interview-style question from learning_plan.md
-4. Wait for the answer; confirm or correct
-5. Dig deeper if correct; break into smaller pieces if confused
-6. Append a short entry to learning_history.md after each concept
+1. Introduce the concept with one concrete real-world example
+2. Ask an interview-style question from learning_plan.md
+3. Wait for the answer; confirm or correct
+4. Dig deeper if correct; break into smaller pieces if confused
+5. Append a short entry to learning_history.md after each concept
 ```
 
 # Your Responsibilities

--- a/initcmd/templates/docker-compose.yml
+++ b/initcmd/templates/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.9'
+
+services:
+  postgres:
+    image: postgres:latest
+    container_name: postgres
+    environment:
+      POSTGRES_USER: acid
+      POSTGRES_PASSWORD: strong_password_123
+      POSTGRES_DB: demo
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U acid -d demo"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  mysql:
+    image: mysql:8
+    container_name: mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: strong_password_123
+      MYSQL_DATABASE: demo
+      MYSQL_USER: acid
+      MYSQL_PASSWORD: strong_password_123
+    ports:
+      - "3306:3306"

--- a/server/server.go
+++ b/server/server.go
@@ -71,6 +71,9 @@ func (s *Server) ListenAndServe() error {
 		w.WriteHeader(http.StatusOK)
 	})
 	mux.HandleFunc("POST /start", func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		s.visible = false
+		s.mu.Unlock()
 		s.ch <- event.Start()
 		w.WriteHeader(http.StatusOK)
 	})

--- a/ui/run/events_table.go
+++ b/ui/run/events_table.go
@@ -183,6 +183,9 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case newEvent:
 		if msg.Event.IsStart() {
 			m.data.clean()
+			if m.serverMode {
+				m.data.onlyStepsMode = true
+			}
 			m.running = true
 			m.UpdateViewport()
 			return m, readNextEvent(m.runner)


### PR DESCRIPTION
## Summary

- Renames the scaffolded `agents.md` to `AGENTS.md` (canonical name used by Codex and other AI tools)
- Creates `CLAUDE.md` and `GEMINI.md` as symlinks to `AGENTS.md` so each AI CLI auto-loads the system prompt without any flags
- Replaces the broken `claude --system-prompt agents.md` instruction with just `claude`
- Tightens the `agents.md` template: removes upfront "what do you know" questions, streamlines Mode A/B teaching loops

## Test plan

- [ ] Run `acid init /tmp/test` and verify `AGENTS.md` is a real file, `CLAUDE.md` and `GEMINI.md` are symlinks pointing to `AGENTS.md`
- [ ] Re-run `acid init /tmp/test` and verify all three are skipped (exists check)
- [ ] Confirm post-init "Next steps" shows `claude` with no flags
- [ ] Start `claude` inside the scaffolded dir and confirm it picks up the coach persona via `CLAUDE.md`