### PR TITLE
Improve learning agent visibility: drop_tables param and auto-show setup

### DIFF
--- a/config/toml.go
+++ b/config/toml.go
@@ -21,6 +21,7 @@ type file struct {
 	Name          string     `toml:"name"`
 	Description   string     `toml:"description"`
 	LearningLinks []string   `toml:"learning_links"`
+	DropTables    []string   `toml:"drop_tables"`
 	Steps         []fileStep `toml:"steps"`
 }
 
@@ -43,6 +44,7 @@ func Load(path string) (sequence.Sequence, error) {
 		Name:          f.Name,
 		Description:   f.Description,
 		LearningLinks: f.LearningLinks,
+		DropTables:    f.DropTables,
 		Calls:         steps,
 	}, nil
 }

--- a/initcmd/templates/agents.md
+++ b/initcmd/templates/agents.md
@@ -43,10 +43,11 @@ prediction-first learning.
 name = "Scenario Name"
 description = "What this scenario demonstrates"
 learning_links = ["https://..."]   # optional
+drop_tables = ["t"]                # dropped before steps run; omit or [] for no cleanup
 
 [[steps]]
-sql   = "drop table if exists t"
-setup = true    # setup steps are hidden by default in the TUI (press 's' to reveal)
+sql   = "create table t (...)"
+setup = true    # setup steps are shown automatically in server mode; press 's' to toggle
 
 [[steps]]
 cmd = "begin"   # begin | commit | rollback

--- a/initcmd/templates/sequences/dirty_read.toml
+++ b/initcmd/templates/sequences/dirty_read.toml
@@ -10,9 +10,7 @@ learning_links = [
   "https://en.wikipedia.org/wiki/Isolation_(database_systems)#Dirty_reads",
 ]
 
-[[steps]]
-sql   = "drop table if exists orders"
-setup = true
+drop_tables = ["orders"]
 
 [[steps]]
 sql   = "create table orders (id serial primary key, customer text not null, amount integer not null)"

--- a/initcmd/templates/sequences/lost_update.toml
+++ b/initcmd/templates/sequences/lost_update.toml
@@ -8,9 +8,7 @@ learning_links = [
   "https://en.wikipedia.org/wiki/Write%E2%80%93write_conflict",
 ]
 
-[[steps]]
-sql   = "drop table if exists accounts"
-setup = true
+drop_tables = ["accounts"]
 
 [[steps]]
 sql   = "create table accounts (id integer primary key, owner text not null, balance integer not null)"

--- a/initcmd/templates/sequences/non_repeatable_read.toml
+++ b/initcmd/templates/sequences/non_repeatable_read.toml
@@ -10,9 +10,7 @@ learning_links = [
   "https://en.wikipedia.org/wiki/Isolation_(database_systems)#Non-repeatable_reads",
 ]
 
-[[steps]]
-sql   = "drop table if exists prices"
-setup = true
+drop_tables = ["prices"]
 
 [[steps]]
 sql   = "create table prices (id integer primary key, product text not null, price integer not null)"

--- a/initcmd/templates/sequences/phantom_read.toml
+++ b/initcmd/templates/sequences/phantom_read.toml
@@ -9,9 +9,7 @@ learning_links = [
   "https://en.wikipedia.org/wiki/Isolation_(database_systems)#Phantom_reads",
 ]
 
-[[steps]]
-sql   = "drop table if exists users"
-setup = true
+drop_tables = ["users"]
 
 [[steps]]
 sql   = "create table users (id serial primary key, name text not null, active boolean not null default true)"

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -31,6 +31,15 @@ func (r *Runner) Run(sequence sequence.Sequence) <-chan event.Event {
 	go func() {
 		r.store.ResetAll()
 
+		for _, table := range sequence.DropTables {
+			step := call.Setup("DROP TABLE IF EXISTS " + table)
+			result := step.Exec(r.store, nil)
+			if result.Error != nil {
+				results <- event.Call(step, nil)
+				results <- event.Result(step, result, nil)
+			}
+		}
+
 		wg := sync.WaitGroup{}
 
 		for i, step := range sequence.Calls {

--- a/sequence/sequence.go
+++ b/sequence/sequence.go
@@ -7,4 +7,5 @@ type Sequence struct {
 	Description   string
 	Calls         []call.Step
 	LearningLinks []string
+	DropTables    []string
 }

--- a/sequence/sequences.go
+++ b/sequence/sequences.go
@@ -15,12 +15,12 @@ var TrxSpeech = []Sequence{
 	{
 		Name:        "Lost Update example",
 		Description: "There is a potential bug",
+		DropTables:  []string{"speaker_slots"},
 		Calls: []call.Step{
-			call.Setup("drop table if exists speaker_slots"),
 			call.Setup(`CREATE TABLE speaker_slots (
-    meetup_id INTEGER NOT NULL, 
+    meetup_id INTEGER NOT NULL,
     speaker_id INTEGER DEFAULT NULL,
-    start_time INTEGER NOT NULL DEFAULT 1, 
+    start_time INTEGER NOT NULL DEFAULT 1,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
     PRIMARY KEY(meetup_id, start_time)
 )`),
@@ -40,12 +40,12 @@ var TrxSpeech = []Sequence{
 	{
 		Name:        "Lost Update fix",
 		Description: "Fix lost update",
+		DropTables:  []string{"speaker_slots"},
 		Calls: []call.Step{
-			call.Setup("drop table if exists speaker_slots"),
 			call.Setup(`CREATE TABLE speaker_slots (
-    meetup_id INTEGER NOT NULL, 
+    meetup_id INTEGER NOT NULL,
     speaker_id INTEGER DEFAULT NULL,
-    start_time INTEGER NOT NULL DEFAULT 1, 
+    start_time INTEGER NOT NULL DEFAULT 1,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
     PRIMARY KEY(meetup_id, start_time)
 )`),
@@ -66,9 +66,8 @@ var TrxSpeech = []Sequence{
 	{
 		Name:        "INSERT constraint err example",
 		Description: "Shows how error appear during transaction",
+		DropTables:  []string{"visitors", "meetups"},
 		Calls: []call.Step{
-			call.Setup("drop table if exists meetups"),
-			call.Setup("drop table if exists visitors"),
 			call.Setup(`CREATE TABLE meetups (
     id SERIAL NOT NULL PRIMARY KEY,
     name TEXT NOT NULL,
@@ -101,9 +100,8 @@ var TrxSpeech = []Sequence{
 	{
 		Name:        "INSERT check constraint err example",
 		Description: "Shows how error appear during transaction",
+		DropTables:  []string{"visitors", "meetups"},
 		Calls: []call.Step{
-			call.Setup("drop table if exists meetups"),
-			call.Setup("drop table if exists visitors"),
 			call.Setup(`CREATE TABLE meetups (
     id SERIAL NOT NULL PRIMARY KEY,
     name TEXT NOT NULL,
@@ -140,8 +138,8 @@ var Common = []Sequence{
 	{
 		Name:        "PG Lock",
 		Description: "Lock pg",
+		DropTables:  []string{"for_test"},
 		Calls: []call.Step{
-			call.Setup("drop table if exists for_test"),
 			call.Setup(`CREATE TABLE for_test (
     id INTEGER NOT NULL PRIMARY KEY,
     created_at TIMESTAMP DEFAULT NOW()
@@ -158,8 +156,8 @@ var Common = []Sequence{
 	{
 		Name:        "Insert isolation level",
 		Description: "Shows default isolation level and how it affects received data",
+		DropTables:  []string{"exec_test"},
 		Calls: []call.Step{
-			call.Setup("drop table if exists exec_test"),
 			call.Setup("CREATE TABLE exec_test (id SERIAL PRIMARY KEY, name TEXT)"),
 			call.Begin(tx1),
 			call.Begin(tx2),

--- a/ui/run/events_table.go
+++ b/ui/run/events_table.go
@@ -185,6 +185,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.data.clean()
 			if m.serverMode {
 				m.data.onlyStepsMode = true
+				m.data.showSetupEvents = true
 			}
 			m.running = true
 			m.UpdateViewport()

--- a/ui/theme/keys.go
+++ b/ui/theme/keys.go
@@ -20,12 +20,12 @@ var DefaultKB = KeyBindings{
 	),
 	Mode: key.NewBinding(
 		key.WithKeys("m", tea.KeySpace.String()),
-		key.WithHelp("m/space", "view mode"),
+		key.WithHelp("m/space", "toggle results visibility"),
 	),
 	Learn: key.NewBinding(),
 	ShowSetup: key.NewBinding(
 		key.WithKeys("s"),
-		key.WithHelp("s", "setup sql"),
+		key.WithHelp("s", "toggle setup sql visibility"),
 	),
 }
 


### PR DESCRIPTION
## Summary

- **`drop_tables` sequence parameter**: replaces boilerplate `drop table if exists` setup steps with a top-level `drop_tables = ["t"]` param; drops run silently before the sequence, errors surface in the TUI
- **Auto-show setup in server mode**: on each new run, setup events are shown automatically so students see initial table state (schema, seeded data) without needing to press `s`
- Updated all built-in sequences and template TOMLs to use the new param

## Test plan

- [ ] `acid serve` in one terminal, `acid run -f sequences/lost_update.toml` in another — confirm setup steps appear immediately without pressing `s`
- [ ] Press `s` to confirm setup visibility can still be toggled
- [ ] Confirm transaction results stay hidden until `acid toggle`
- [ ] Run a built-in sequence (`acid run "Lost Update example"`) — confirm drop_tables works silently
- [ ] Introduce a bad table name that can't be dropped to confirm errors surface in the TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)