### PR TITLE
Show terminal-aware split pane instructions in acid serve

### DIFF
--- a/terminal/detect.go
+++ b/terminal/detect.go
@@ -1,0 +1,29 @@
+package terminal
+
+import (
+	"os"
+	"runtime"
+)
+
+// SplitHint returns the keyboard shortcut to split a pane in the detected terminal.
+func SplitHint() string {
+	mod := "Cmd"
+	if runtime.GOOS != "darwin" {
+		mod = "Ctrl+Shift"
+	}
+
+	switch {
+	case os.Getenv("TERM_PROGRAM") == "iTerm.app":
+		return mod + "+D"
+	case os.Getenv("GHOSTTY_RESOURCES_DIR") != "":
+		return mod + "+D"
+	case os.Getenv("KITTY_WINDOW_ID") != "":
+		return "Ctrl+Shift+Enter"
+	case os.Getenv("WEZTERM_PANE") != "":
+		return mod + "+Shift+5"
+	case os.Getenv("TMUX") != "":
+		return `Ctrl+B then %`
+	default:
+		return "your terminal split shortcut"
+	}
+}

--- a/ui/run/events_table.go
+++ b/ui/run/events_table.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rusinikita/acid/call"
 	"github.com/rusinikita/acid/event"
 	"github.com/rusinikita/acid/sequence"
+	"github.com/rusinikita/acid/terminal"
 	"github.com/rusinikita/acid/ui/router"
 	"github.com/rusinikita/acid/ui/theme"
 )
@@ -29,6 +30,7 @@ type model struct {
 
 	help help.Model
 
+	splitHint       string
 	db              string
 	currentSequence int
 	sequences       []sequence.Sequence
@@ -86,8 +88,9 @@ func NewServerRunTable(source runner, port string, toggleCh <-chan struct{}) tea
 		table: t,
 		data:  data,
 
-		help: help.New(),
-		db:   ":" + port,
+		help:      help.New(),
+		splitHint: terminal.SplitHint(),
+		db:        ":" + port,
 	}
 
 	styleFunc := func(row, _ int) lipgloss.Style {
@@ -223,7 +226,17 @@ func (m *model) bordersHeight() int {
 
 func (m *model) View() string {
 	if m.serverMode && len(m.data.events) == 0 {
-		return "Waiting for connection on " + m.db + "...\n\nPress q to quit."
+		label := theme.SQLKeywordStyle.Render
+		dim := theme.EventTypeStyle.Render
+		return fmt.Sprintf(
+			"\n  %s  %s\n\n  %s  %s\n\n  %s  %s  %s  %s\n\n  %s\n\n  %s",
+			label("acid server"), dim("listening on "+m.db),
+			dim("Waiting for agent to connect..."),
+			"",
+			label("1."), "Split this pane:", dim(m.splitHint), "",
+			label("2.")+" In the new pane run:  "+dim("claude")+"  /  "+dim("codex")+"  /  "+dim("gemini")+"    (you can resize the divider)",
+			dim("Press q to quit"),
+		)
 	}
 
 	menuBindings := theme.DefaultKB.Menu()


### PR DESCRIPTION
## Summary

- Adds a `terminal` package that detects the running terminal emulator (iTerm2, Ghostty, Kitty, WezTerm, tmux) via environment variables and returns the correct split-pane keyboard shortcut
- Replaces the bare `"Waiting for connection..."` string in the server TUI with a styled onboarding screen that guides the user to split their pane and launch an AI agent (`claude` / `codex` / `gemini`) there
- Modifier key adapts to OS: `Cmd` on macOS, `Ctrl+Shift` on Linux/Windows

## Test plan

- [ ] `go build ./...` passes
- [ ] `acid serve` in iTerm2 shows `Cmd+D` hint
- [ ] `acid serve` in Ghostty shows `Cmd+D` hint
- [ ] `acid serve` inside tmux shows `Ctrl+B then %` hint
- [ ] Unknown terminal shows generic fallback text
- [ ] Once a sequence runs from the client, normal event table renders without regression