### PR TITLE
Add database connectivity check to acid status

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -6,13 +6,15 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/rusinikita/acid/db"
 )
 
 var statusPort string
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Check if an acid server is running on the given port",
+	Short: "Check database connectivity and acid server reachability",
 	Run: func(cmd *cobra.Command, args []string) {
 		checkStatus()
 	},
@@ -24,18 +26,31 @@ func init() {
 }
 
 func checkStatus() {
+	allOK := true
+
+	if err := db.TryConnect(); err != nil {
+		fmt.Printf("database is NOT reachable: %v\n", err)
+		allOK = false
+	} else {
+		fmt.Println("database is reachable")
+	}
+
 	url := "http://localhost:" + statusPort + "/health"
 	resp, err := http.Get(url) //nolint:noctx
 	if err != nil {
 		fmt.Printf("acid server is NOT running on port %s\n", statusPort)
-		os.Exit(1)
-	}
-	resp.Body.Close()
-
-	if resp.StatusCode == http.StatusOK {
-		fmt.Printf("acid server is running on port %s\n", statusPort)
+		allOK = false
 	} else {
-		fmt.Printf("unexpected response from server: %d\n", resp.StatusCode)
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			fmt.Printf("acid server is running on port %s\n", statusPort)
+		} else {
+			fmt.Printf("unexpected response from server: %d\n", resp.StatusCode)
+			allOK = false
+		}
+	}
+
+	if !allOK {
 		os.Exit(1)
 	}
 }

--- a/db/conn.go
+++ b/db/conn.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -17,6 +18,25 @@ import (
 func LoadEnv(baseDir string) {
 	_ = godotenv.Load(filepath.Join(baseDir, ".env"))
 	_ = godotenv.Load(filepath.Join(filepath.Dir(baseDir), ".env"))
+}
+
+// TryConnect attempts to open and ping the database, returning an error on failure.
+func TryConnect() error {
+	_ = godotenv.Load(".env")
+	_ = godotenv.Load("../.env")
+	_ = godotenv.Load("../../.env")
+
+	database, err := sql.Open(os.Getenv("DB_DRIVER"), os.Getenv("DB_CONNECT"))
+	if err != nil {
+		return fmt.Errorf("open: %w", err)
+	}
+	defer database.Close()
+
+	if err := database.Ping(); err != nil {
+		return fmt.Errorf("ping: %w", err)
+	}
+
+	return nil
 }
 
 func Connect() *sql.DB {

--- a/initcmd/templates/agents.md
+++ b/initcmd/templates/agents.md
@@ -26,7 +26,7 @@ interleaved SQL from multiple named transactions and shows the results in a live
 ```
 acid                          Standalone TUI with built-in sequences (no server needed)
 acid serve [--port N]         Start server TUI on :7331; shows results as acid run sends them
-acid status [--port N]        Print "OK" if server is reachable, or an error message
+acid status [--port N]        Check database connectivity and acid server reachability
 acid run <name>               Run a built-in sequence by name  (e.g. acid run lost_update)
 acid run -f path/to.toml      Run a TOML scenario file, stream results to acid serve
 acid toggle [--port N]        Toggle result visibility on the running server
@@ -66,9 +66,9 @@ sql = "select * from t"
 
 **Student's only responsibility**: open a terminal and run `acid serve`.
 
-**Your responsibility**: run `acid status` yourself to confirm the server is live before teaching
-begins. If it fails, help troubleshoot (.env file, DB connection string, port conflicts). Do not
-start teaching until status is OK.
+**Your responsibility**: run `acid status` yourself to confirm both the database is reachable
+and the server is live before teaching begins. If either check fails, help troubleshoot (.env
+file, DB connection string, port conflicts). Do not start teaching until both checks pass.
 
 # Two Teaching Modes
 


### PR DESCRIPTION
## Summary

- `acid status` now checks **both** database connectivity and server reachability, reporting each independently
- Added `db.TryConnect() error` — a non-fatal variant of `Connect()` that returns an error instead of panicking
- Agent instructions updated: `acid status` description and Setup section now mention the DB check explicitly

## Test plan

- [ ] `acid status` with DB up + server up → two green lines, exit 0
- [ ] `acid status` with DB down → DB error line shown, exit 1
- [ ] `acid status` with server down → DB OK line shown, server error line shown, exit 1
- [ ] `go build ./...` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)