### PR TITLE
(doc) fix readme install instruction via brew for macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ acid run "Phantom Reads"
 
 ```bash
 # macOS (Homebrew)
-brew install --cask rusinikita/acid/acid
+brew install --cask rusinikita/tap/acid
 
 # Linux / macOS (shell script)
 curl -fsSL https://raw.githubusercontent.com/rusinikita/acid/main/install.sh | sh


### PR DESCRIPTION
   ## Summary
   - Fixes the macOS Homebrew install instruction: tap is `rusinikita/tap`, not `rusinikita/acid`.

   ## Test plan
   - [x] `brew install --cask rusinikita/tap/acid` succeeds on macOS